### PR TITLE
Update java-policy.md

### DIFF
--- a/docs/java-policy.md
+++ b/docs/java-policy.md
@@ -1,2 +1,3 @@
 ## Java Development
+Please use java 17 version
 Please use gradle to build project


### PR DESCRIPTION
This pull request includes an update to the `docs/java-policy.md` file. The change specifies that Java 17 should be used for development.

* [`docs/java-policy.md`](diffhunk://#diff-f2dba36156dff7620b9bb8343675576fdacfcaffaabddde1472706af3600d420R2): Added a note to use Java 17 for development.